### PR TITLE
Add overwriting of existing asset with new one

### DIFF
--- a/Assets/Im/Script/KeyframeReduction.cs
+++ b/Assets/Im/Script/KeyframeReduction.cs
@@ -298,9 +298,25 @@ public class KeyframeReduction : EditorWindow
         string path = unique
             ? AssetDatabase.GenerateUniqueAssetPath(rawPath)
             : rawPath;
-        AssetDatabase.CreateAsset(clip, path);
+        OverwriteAsset(clip, path);
         AssetDatabase.SaveAssets();
         AssetDatabase.Refresh();
+    }
+
+    private void OverwriteAsset(UnityEngine.Object asset, string path) {
+        if(File.Exists(path)) {
+            string tmpDirPath = Path.Combine(Path.GetDirectoryName(path), "tmpOverwrite");
+            Directory.CreateDirectory(tmpDirPath);
+
+            string tmpPath = Path.Combine(tmpDirPath, Path.GetFileName(path));
+            AssetDatabase.CreateAsset(asset, tmpPath);
+
+            FileUtil.ReplaceFile(tmpPath, path);
+            AssetDatabase.DeleteAsset(tmpDirPath);
+            AssetDatabase.ImportAsset(path);
+        } else {
+            AssetDatabase.CreateAsset(asset, path);
+        }
     }
 }
 


### PR DESCRIPTION
Output Clipに既存のAnimationClipを指定した場合に、metaファイルを変更せずにアセットを上書きするようにします。
これによって、出力前に使用していたOutput Clipへの参照が出力後にMissingになりません。